### PR TITLE
javac -version, when it’s not absent, may exit with something but zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ hxjava
 [![TravisCI Build Status](https://travis-ci.org/HaxeFoundation/hxjava.svg?branch=master)](https://travis-ci.org/HaxeFoundation/hxjava)
 
 Haxe Java support library. Build scripts and support code.
+
+## To build it
+
+`cd build-tool && haxe build.hxml`

--- a/build-tool/src/compiler/java/Javac.hx
+++ b/build-tool/src/compiler/java/Javac.hx
@@ -267,7 +267,7 @@ class Javac extends Compiler
 
 			var cmd = new Process(exe, ["-version"]);
 			var ret = cmd.exitCode();
-			if (ret == 0)
+			if (ret != 127)
 				return path;
 		}
 		catch (e:Dynamic) { }


### PR DESCRIPTION
this leads to “ Java compiler not found. Please make sure ... ”
when I have javac just in /usr/bin as well as when I set JAVA_HOME
and did export PATH=$JAVA_HOME/bin:$PATH and such

on my side it exits with
   $ javac -version
   javac 1.5.0_30
   javac: no source files
   ...
   $ echo $?
   2

so hxjava’s build-tool/src/compiler/java/Javac.hx fails for me

there’s no guarantee that existing program always exits with EXIT_SUCCESS, but there’s
“ value 127 is returned when it is not found within your PATH system variable ”

so when you want to check if program is absent, just check for its exit code is not 127