### PR TITLE
retain LocalVariableTable

### DIFF
--- a/jar-tool/Main.hx
+++ b/jar-tool/Main.hx
@@ -1,18 +1,19 @@
 package;
 
 import haxe.io.Path;
-import sys.FileSystem;
-import java.StdTypes.Int8;
+import java.Lib.println;
 import java.NativeArray;
-import java.io.FileOutputStream;
+import java.StdTypes.Int8;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.nio.file.Files;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes.Opcodes_Statics;
-import java.Lib.println;
+import sys.FileSystem;
 
 using StringTools;
 
@@ -82,7 +83,7 @@ class CustomClassVisitor extends ClassVisitor {
 	 */
 	@:overload
 	override function visitMethod(access:Int, name:String, desc:String, signature:String, exceptions:NativeArray<String>):MethodVisitor {
-		final mv:MethodVisitor = cv.visitMethod(access, name, desc, signature, exceptions);
+		final mv = cv.visitMethod(access, name, desc, signature, exceptions);
 		if (mv != null) {
 			return new CustomMethodVisitor(mv);
 		}
@@ -97,6 +98,11 @@ class CustomMethodVisitor extends MethodVisitor {
 	public function new(target:MethodVisitor) {
 		super(Opcodes_Statics.ASM7, null);
 		this.target = target;
+	}
+
+	@:overload
+	override function visitLocalVariable(name:String, descriptor:String, signature:String, start:Label, end:Label, index:Int):Void {
+		target.visitLocalVariable(name, descriptor, signature, start, end, index);
 	}
 
 	@:overload

--- a/jar-tool/Main.hx
+++ b/jar-tool/Main.hx
@@ -12,7 +12,11 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+#if (haxe_ver >= 4.2)
+import org.objectweb.asm.Opcodes as Opcodes_Statics;
+#else
 import org.objectweb.asm.Opcodes.Opcodes_Statics;
+#end
 import sys.FileSystem;
 
 using StringTools;


### PR DESCRIPTION
Hi :) 
It works for nightly Haxe, and argument names are parsing fine from jars. 
But I can't run Haxe's unit tests, so somebody should do it instead of me :)

Closes #34

-------------
But be aware, probably something was changed in the nightly builds, so this line:
https://github.com/HaxeFoundation/hxjava/blob/master/jar-tool/Main.hx#L14
is not available anymore with nightly Haxe, and should be rewritten like this: `import org.objectweb.asm.Opcodes` and `Opcodes_Statics` should be used like this: `Opcodes.ASM7` instead of `Opcodes_Statics.ASM7`

It will work for autocompletion, but the compilation process will be failed because of: 
```
Main.hx:75: characters 17-21 : Class<org.objectweb.asm.Opcodes> has no field ASM7
Main.hx:75: characters 17-21 : Class<org.objectweb.asm.Opcodes> has no field ASM7
Main.hx:101: characters 17-21 : Class<org.objectweb.asm.Opcodes> has no field ASM7
Main.hx:101: characters 17-21 : Class<org.objectweb.asm.Opcodes> has no field ASM7
```
So, current sources work with Haxe 4.1.4, but not work with the nightly build.